### PR TITLE
Convert Rotational Power to a Capability.

### DIFF
--- a/src/main/java/exnihilocreatio/ExNihiloCreatio.java
+++ b/src/main/java/exnihilocreatio/ExNihiloCreatio.java
@@ -80,6 +80,7 @@ public class ExNihiloCreatio {
         if (ModConfig.mechanics.enableBarrels) {
             BarrelModeRegistry.registerDefaults();
         }
+
     }
 
     @EventHandler

--- a/src/main/java/exnihilocreatio/capabilities/ENCapabilities.java
+++ b/src/main/java/exnihilocreatio/capabilities/ENCapabilities.java
@@ -1,9 +1,11 @@
 package exnihilocreatio.capabilities;
 
+import exnihilocreatio.rotationalPower.*;
 import net.minecraftforge.common.capabilities.CapabilityManager;
 
 public class ENCapabilities {
     public static void init() {
         CapabilityManager.INSTANCE.register(ICapabilityHeat.class, CapabilityHeatManager.INSTANCE, CapabilityHeatManager.INSTANCE);
+        CapabilityManager.INSTANCE.register(IRotationalPowerMember.class, CapabilityRotationalMember.INSTANCE, CapabilityRotationalMember.INSTANCE);
     }
 }

--- a/src/main/java/exnihilocreatio/rotationalPower/CapabilityRotationalMember.java
+++ b/src/main/java/exnihilocreatio/rotationalPower/CapabilityRotationalMember.java
@@ -1,0 +1,50 @@
+package exnihilocreatio.rotationalPower;
+
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.CapabilityInject;
+
+import javax.annotation.Nullable;
+import java.util.concurrent.Callable;
+
+public class CapabilityRotationalMember implements Capability.IStorage<IRotationalPowerMember>, Callable<IRotationalPowerMember> {
+
+    @SuppressWarnings("CanBeFinal")
+    @CapabilityInject(IRotationalPowerMember.class)
+    public static Capability<IRotationalPowerMember> ROTIONAL_MEMBER = null;
+
+    public static final CapabilityRotationalMember INSTANCE = new CapabilityRotationalMember();
+
+    @Nullable
+    @Override
+    public NBTBase writeNBT(Capability<IRotationalPowerMember> capability, IRotationalPowerMember instance, EnumFacing side) {
+        return null;
+    }
+
+    @Override
+    public void readNBT(Capability<IRotationalPowerMember> capability, IRotationalPowerMember instance, EnumFacing side, NBTBase nbt) {
+
+    }
+
+    @Override
+    public IRotationalPowerMember call() throws Exception {
+        return new IRotationalPowerMember() {
+
+            @Override
+            public float getOwnRotation() {
+                return 0;
+            }
+
+            @Override
+            public float getEffectivePerTickRotation(EnumFacing side) {
+                return 0;
+            }
+
+            @Override
+            public void setEffectivePerTickRotation(float rotation) {
+
+            }
+        };
+    }
+}

--- a/src/main/java/exnihilocreatio/rotationalPower/IRotationalPowerConsumer.java
+++ b/src/main/java/exnihilocreatio/rotationalPower/IRotationalPowerConsumer.java
@@ -1,6 +1,8 @@
 package exnihilocreatio.rotationalPower;
 
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 
 public interface IRotationalPowerConsumer extends IRotationalPowerMember {
     @Override
@@ -14,4 +16,9 @@ public interface IRotationalPowerConsumer extends IRotationalPowerMember {
     }
 
     float getMachineRotationPerTick();
+
+    @Override
+    default float calcEffectivePerTickRotation(World world, BlockPos pos, EnumFacing facing) {
+        return -IRotationalPowerMember.super.calcEffectivePerTickRotation(world, pos, facing.getOpposite());
+    }
 }

--- a/src/main/java/exnihilocreatio/rotationalPower/IRotationalPowerConsumer.java
+++ b/src/main/java/exnihilocreatio/rotationalPower/IRotationalPowerConsumer.java
@@ -19,6 +19,6 @@ public interface IRotationalPowerConsumer extends IRotationalPowerMember {
 
     @Override
     default float calcEffectivePerTickRotation(World world, BlockPos pos, EnumFacing facing) {
-        return -IRotationalPowerMember.super.calcEffectivePerTickRotation(world, pos, facing.getOpposite());
+        return IRotationalPowerMember.super.calcEffectivePerTickRotation(world, pos, facing);
     }
 }

--- a/src/main/java/exnihilocreatio/rotationalPower/IRotationalPowerMember.java
+++ b/src/main/java/exnihilocreatio/rotationalPower/IRotationalPowerMember.java
@@ -1,6 +1,8 @@
 package exnihilocreatio.rotationalPower;
 
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 
 public interface IRotationalPowerMember {
 
@@ -19,5 +21,13 @@ public interface IRotationalPowerMember {
 
     default void addEffectiveRotation(float rotation) {
         setEffectivePerTickRotation(getOwnRotation() + rotation);
+    }
+
+    default float calcEffectivePerTickRotation(World world, BlockPos pos, EnumFacing facing) {
+        BlockPos offset = pos.offset(facing);
+        IRotationalPowerMember m = RotationalUtils.getPowerMember(world, offset, facing);
+        if (m != null)
+            return m.getEffectivePerTickRotation(facing) + getOwnRotation();
+        return getOwnRotation();
     }
 }

--- a/src/main/java/exnihilocreatio/rotationalPower/IRotationalPowerMember.java
+++ b/src/main/java/exnihilocreatio/rotationalPower/IRotationalPowerMember.java
@@ -24,7 +24,7 @@ public interface IRotationalPowerMember {
     }
 
     default float calcEffectivePerTickRotation(World world, BlockPos pos, EnumFacing facing) {
-        BlockPos offset = pos.offset(facing);
+        BlockPos offset = pos.offset(facing.getOpposite());
         IRotationalPowerMember m = RotationalUtils.getPowerMember(world, offset, facing);
         if (m != null)
             return m.getEffectivePerTickRotation(facing) + getOwnRotation();

--- a/src/main/java/exnihilocreatio/rotationalPower/RotationalUtils.java
+++ b/src/main/java/exnihilocreatio/rotationalPower/RotationalUtils.java
@@ -1,0 +1,18 @@
+package exnihilocreatio.rotationalPower;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+public class RotationalUtils {
+
+    public static IRotationalPowerMember getPowerMember(World world, BlockPos pos, EnumFacing facing) {
+        TileEntity tile = world.getTileEntity(pos);
+        if(tile != null && tile.hasCapability(CapabilityRotationalMember.ROTIONAL_MEMBER, facing)) {
+            return tile.getCapability(CapabilityRotationalMember.ROTIONAL_MEMBER, facing);
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/exnihilocreatio/tiles/TileAutoSifter.java
+++ b/src/main/java/exnihilocreatio/tiles/TileAutoSifter.java
@@ -1,8 +1,8 @@
 package exnihilocreatio.tiles;
 
 import exnihilocreatio.config.ModConfig;
+import exnihilocreatio.rotationalPower.CapabilityRotationalMember;
 import exnihilocreatio.rotationalPower.IRotationalPowerConsumer;
-import exnihilocreatio.rotationalPower.IRotationalPowerMember;
 import exnihilocreatio.util.BlockInfo;
 import exnihilocreatio.util.Util;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
@@ -55,8 +55,8 @@ public class TileAutoSifter extends BaseTileEntity implements ITickable, IRotati
             offsetX = cx + r * (float) Math.cos(tickCounter);
         }
 
-        if (tickCounter % 10 == 0) {
-            perTickRotation = calcEffectivePerTickRotation(facing);
+        if (tickCounter > 0 && tickCounter % 10 == 0) {
+            perTickRotation = calcEffectivePerTickRotation(world, pos, facing);
 
             BlockPos posOther = pos.up();
             TileEntity te = world.getTileEntity(posOther);
@@ -66,6 +66,7 @@ public class TileAutoSifter extends BaseTileEntity implements ITickable, IRotati
             } else {
                 toSift = null;
             }
+            tickCounter = 0;
         }
 
         storedRotationalPower += perTickRotation;
@@ -169,29 +170,20 @@ public class TileAutoSifter extends BaseTileEntity implements ITickable, IRotati
         perTickRotation = rotation;
     }
 
-    private float calcEffectivePerTickRotation(EnumFacing direction) {
-        if (facing == direction) {
-            BlockPos posProvider = pos.offset(facing.getOpposite());
-            TileEntity te = world.getTileEntity(posProvider);
-            if (te != null && te instanceof IRotationalPowerMember) {
-                return ((IRotationalPowerMember) te).getEffectivePerTickRotation(facing) + getOwnRotation();
-            } else return getOwnRotation();
-        } else return 0;
-    }
-
     @SuppressWarnings("unchecked")
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing facing) {
-        if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
-            return (T) itemHandlerAutoSifter;
-        }
-
+        if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
+            return CapabilityItemHandler.ITEM_HANDLER_CAPABILITY.cast(itemHandlerAutoSifter);
+        if (capability == CapabilityRotationalMember.ROTIONAL_MEMBER)
+            return CapabilityRotationalMember.ROTIONAL_MEMBER.cast(this);
         return super.getCapability(capability, facing);
     }
 
     @Override
     public boolean hasCapability(@Nonnull Capability<?> capability, EnumFacing facing) {
         return capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY ||
+                (capability == CapabilityRotationalMember.ROTIONAL_MEMBER && facing == this.facing) ||
                 super.hasCapability(capability, facing);
     }
 

--- a/src/main/java/exnihilocreatio/tiles/TileStoneAxle.java
+++ b/src/main/java/exnihilocreatio/tiles/TileStoneAxle.java
@@ -1,13 +1,16 @@
 package exnihilocreatio.tiles;
 
+import exnihilocreatio.rotationalPower.CapabilityRotationalMember;
 import exnihilocreatio.rotationalPower.IRotationalPowerMember;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ITickable;
 import net.minecraft.util.math.BlockPos;
+import net.minecraftforge.common.capabilities.Capability;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public class TileStoneAxle extends BaseTileEntity implements ITickable, IRotationalPowerMember {
     public float rotationValue = 0;
@@ -21,13 +24,14 @@ public class TileStoneAxle extends BaseTileEntity implements ITickable, IRotatio
     public void update() {
         counter++;
 
-        if (counter % 10 == 0) {
+        if (counter > 0 && counter % 10 == 0) {
             float lastPerTickEffective = perTickEffective;
-            perTickEffective = calcEffectivePerTickRotation(facing);
+            perTickEffective = calcEffectivePerTickRotation(world, pos, facing);
 
             if (lastPerTickEffective != perTickEffective) {
                 markDirty();
             }
+            counter = 0;
         }
 
         if (world.isRemote) {
@@ -69,14 +73,18 @@ public class TileStoneAxle extends BaseTileEntity implements ITickable, IRotatio
         }
     }
 
-    private float calcEffectivePerTickRotation(EnumFacing direction) {
-        if (facing == direction) {
-            BlockPos posProvider = pos.offset(facing.getOpposite());
-            TileEntity te = world.getTileEntity(posProvider);
-            if (te != null && te instanceof IRotationalPowerMember) {
-                return ((IRotationalPowerMember) te).getEffectivePerTickRotation(facing) + getOwnRotation();
-            } else return getOwnRotation();
-        } else return 0;
+    @Override
+    public boolean hasCapability(Capability<?> capability, @Nullable EnumFacing facing) {
+        if (capability == CapabilityRotationalMember.ROTIONAL_MEMBER && facing == this.facing)
+            return true;
+        return super.hasCapability(capability, facing);
+    }
+
+    @Override
+    public <T> T getCapability(Capability<T> capability, @Nullable EnumFacing facing) {
+        if (capability == CapabilityRotationalMember.ROTIONAL_MEMBER && facing == this.facing)
+            return CapabilityRotationalMember.ROTIONAL_MEMBER.cast(this);
+        return super.getCapability(capability, facing);
     }
 
     @Override


### PR DESCRIPTION
This makes a CapabilityRotationalMember which allows other mods to simply attach this to their blocks for compatibility.
In doing this I moved `calcEffectivePerTickRotation` from all of the different tiles into IRotationalPowerMember as a default method as to lessen the duplicated code and use capability rather than interface detection.

Also a small thing I did, I noticed that the tick counters for the tileentities were continuously increasing, this after long enough could be an issue, so they reset to 0 every successful tick.