### PR TITLE
Fix reference to EnderIO Grains of infinity

### DIFF
--- a/src/main/java/exnihilocreatio/recipes/defaults/EnderIO.java
+++ b/src/main/java/exnihilocreatio/recipes/defaults/EnderIO.java
@@ -10,14 +10,14 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
 @SuppressWarnings("ConstantConditions")
 public class EnderIO implements IRecipeDefaults {
     @GameRegistry.ObjectHolder("enderio:item_material")
-    // 21 = Grains of Infinity/Bedrock Dust
+    // 20 = Grains of Infinity/Bedrock Dust
     public static final Item EIO_DUST_BEDROCK = null;
     @Getter
     public String MODID = "enderio";
 
     public void registerSieve(SieveRegistry registry) {
         if (EIO_DUST_BEDROCK != null){
-            registry.register("dust", new ItemInfo(EIO_DUST_BEDROCK, 21), 0.01f, BlockSieve.MeshType.DIAMOND.getID());
+            registry.register("dust", new ItemInfo(EIO_DUST_BEDROCK, 20), 0.01f, BlockSieve.MeshType.DIAMOND.getID());
         }
     }
 }


### PR DESCRIPTION
The ID for Grains of Infinity is 20.
This referenced Flour instead.