### PR TITLE
0.3.8.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
-enc_version=0.3.8.1
+enc_version=0.3.8.2
 
 mc_version=1.12.2
 mc_major=1.12
 
-forge_version=14.23.5.2810
+forge_version=14.23.5.2815
 mappings_version=stable_39
 
 forgelin_version=1.8.2

--- a/src/main/java/exnihilocreatio/blocks/BlockSieve.java
+++ b/src/main/java/exnihilocreatio/blocks/BlockSieve.java
@@ -28,6 +28,7 @@ import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.FakePlayer;
+import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 import p455w0rd.danknull.util.DankNullUtils;
@@ -80,10 +81,14 @@ public class BlockSieve extends BlockBase implements ITileEntityProvider, ITOPIn
             cap = new ItemStackItemHandler(heldItem);
 
         int slot = 0;
-        if(ModConfig.compatibility.dankNullIntegration && DankNullUtils.isDankNull(heldItem)){
+        int maxSlot = cap.getSlots();
+        if(Loader.isModLoaded("danknull") &&
+                ModConfig.compatibility.dankNullIntegration &&
+                DankNullUtils.isDankNull(heldItem)){
             slot = DankNullUtils.getSelectedStackIndex(DankNullUtils.getInventoryFromHeld(player));
+            maxSlot = slot + 1;
         }
-        while(slot < cap.getSlots() + 1){
+        for(;slot < maxSlot; slot++){
             ItemStack stack = cap.getStackInSlot(slot);
             if(!stack.isEmpty() && stack.getItem() instanceof ItemMesh){
                 // Adding a mesh
@@ -113,10 +118,6 @@ public class BlockSieve extends BlockBase implements ITileEntityProvider, ITOPIn
                 }
                 return true;
             }
-            if(ModConfig.compatibility.dankNullIntegration && DankNullUtils.isDankNull(heldItem)){
-                break; // Dank Nulls should only operate on their single stack
-            }
-            slot++;
         }
 
         List<BlockPos> toSift = new ArrayList<>();

--- a/src/main/java/exnihilocreatio/networking/MessageCompostUpdate.java
+++ b/src/main/java/exnihilocreatio/networking/MessageCompostUpdate.java
@@ -117,14 +117,16 @@ public class MessageCompostUpdate implements IMessage {
 
                     if (entity instanceof TileBarrel) {
                         TileBarrel te = (TileBarrel) entity;
+                        if(te.getMode() == null || !(te.getMode() instanceof BarrelModeCompost))
+                            te.setMode("compost");
                         BarrelModeCompost mode = (BarrelModeCompost) te.getMode();
                         mode.setFillAmount(msg.fillAmount);
 
-                        if (msg.stack.isEmpty() && msg.compValue == 0.0f){
+                        if (msg.stack.isEmpty() && msg.compValue == 0.0f && mode.getOriginalColor() != null){
                             // Progress is being made
                             mode.setColor(Color.average(mode.getOriginalColor(), whiteColor, msg.progress));
                         } else {
-                            // A new item is getting added
+                            // A new item is getting added or the Color has been desynced.
                             Color compColor = msg.color;
                             // Dynamic color on invalid_color
                             if (compColor.equals(Color.INVALID_COLOR) && !msg.stack.isEmpty()) {

--- a/src/main/java/exnihilocreatio/util/ItemUtil.kt
+++ b/src/main/java/exnihilocreatio/util/ItemUtil.kt
@@ -48,5 +48,5 @@ fun isHammer(item: Item): Boolean {
  * Compares Items, Damage, and NBT
  */
 fun areStacksEquivalent(left: ItemStack, right: ItemStack) : Boolean{
-    return ItemStack.areItemStacksEqual(left, right) && ItemStack.areItemStackTagsEqual(left, right)
+    return ItemStack.areItemsEqual(right, left) && ItemStack.areItemStackTagsEqual(left, right)
 }


### PR DESCRIPTION
Issue #163, Issue #167, Issue #169. 5 minute fixes, hours to get gradle working again.

Fix when /dank/null isn't installed; s/Items/Itemstack/; fix log spam when barrels get desynced if they change mode while a user is outside the tileentity render range but within the chunk load distance.