### PR TITLE
Broken tinker's tools no longer register as valid hammers/crooks.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-enc_version=0.4.3.1
+enc_version=0.4.3.2
 
 mc_version=1.12.2
 mc_major=1.12

--- a/src/main/java/exnihilocreatio/compatibility/jei/CompatJEI.java
+++ b/src/main/java/exnihilocreatio/compatibility/jei/CompatJEI.java
@@ -4,8 +4,8 @@ import exnihilocreatio.ExNihiloCreatio;
 import exnihilocreatio.ModBlocks;
 import exnihilocreatio.compatibility.jei.barrel.compost.CompostRecipe;
 import exnihilocreatio.compatibility.jei.barrel.compost.CompostRecipeCategory;
-import exnihilocreatio.compatibility.jei.barrel.fluidblocktransform.FluidBlockTransformRecipe;
-import exnihilocreatio.compatibility.jei.barrel.fluidblocktransform.FluidBlockTransformRecipeCategory;
+import exnihilocreatio.compatibility.jei.barrel.fluiditemtransform.FluidItemTransformRecipe;
+import exnihilocreatio.compatibility.jei.barrel.fluiditemtransform.FluidItemTransformRecipeCategory;
 import exnihilocreatio.compatibility.jei.barrel.fluidontop.FluidOnTopRecipe;
 import exnihilocreatio.compatibility.jei.barrel.fluidontop.FluidOnTopRecipeCategory;
 import exnihilocreatio.compatibility.jei.barrel.fluidtransform.FluidTransformRecipe;
@@ -64,7 +64,7 @@ public class CompatJEI implements IModPlugin {
         registry.addRecipeCategories(new CrookRecipeCategory(guiHelper));
         registry.addRecipeCategories(new FluidOnTopRecipeCategory(guiHelper));
         registry.addRecipeCategories(new FluidTransformRecipeCategory(guiHelper));
-        registry.addRecipeCategories(new FluidBlockTransformRecipeCategory(guiHelper));
+        registry.addRecipeCategories(new FluidItemTransformRecipeCategory(guiHelper));
         registry.addRecipeCategories(new CompostRecipeCategory(guiHelper));
         registry.addRecipeCategories(new CrucibleRecipeCategory(guiHelper, "exnihilocreatio:crucible_wood"));
         registry.addRecipeCategories(new CrucibleRecipeCategory(guiHelper, "exnihilocreatio:crucible_stone"));
@@ -111,12 +111,13 @@ public class CompatJEI implements IModPlugin {
 
 
     private void registerFluidBlockTransform(@Nonnull IModRegistry registry) {
-        List<FluidBlockTransformRecipe> fluidBlockTransformRecipes = ExNihiloRegistryManager.FLUID_BLOCK_TRANSFORMER_REGISTRY.getRecipeList();
+        List<FluidItemTransformRecipe> fluidItemTransformRecipes = ExNihiloRegistryManager.FLUID_BLOCK_TRANSFORMER_REGISTRY.getRecipeList();
+        fluidItemTransformRecipes.addAll(ExNihiloRegistryManager.FLUID_ITEM_FLUID_REGISTRY.getRecipeList());
 
-        registry.addRecipes(fluidBlockTransformRecipes, FluidBlockTransformRecipeCategory.UID);
-        registry.addRecipeCatalyst(new ItemStack(ModBlocks.barrelWood), FluidBlockTransformRecipeCategory.UID);
-        registry.addRecipeCatalyst(new ItemStack(ModBlocks.barrelStone), FluidBlockTransformRecipeCategory.UID);
-        LogUtil.info("JEI: Fluid Block Transform Recipes Loaded:       " + fluidBlockTransformRecipes.size());
+        registry.addRecipes(fluidItemTransformRecipes, FluidItemTransformRecipeCategory.UID);
+        registry.addRecipeCatalyst(new ItemStack(ModBlocks.barrelWood), FluidItemTransformRecipeCategory.UID);
+        registry.addRecipeCatalyst(new ItemStack(ModBlocks.barrelStone), FluidItemTransformRecipeCategory.UID);
+        LogUtil.info("JEI: Fluid Item Transform Recipes Loaded:       " + fluidItemTransformRecipes.size());
     }
 
     private void registerFluidOnTop(@Nonnull IModRegistry registry) {

--- a/src/main/java/exnihilocreatio/compatibility/jei/barrel/fluiditemtransform/FluidItemTransformRecipe.java
+++ b/src/main/java/exnihilocreatio/compatibility/jei/barrel/fluiditemtransform/FluidItemTransformRecipe.java
@@ -12,6 +12,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
+import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
@@ -27,6 +28,8 @@ public class FluidItemTransformRecipe implements IRecipeWrapper {
     @Nonnull
     private final List<ItemStack> inputStacks;
 
+    @Nullable
+    private final FluidStack outputFluid;
     @Nonnull
     private final ItemStack outputStack;
 
@@ -37,6 +40,7 @@ public class FluidItemTransformRecipe implements IRecipeWrapper {
 
         inputStacks = Arrays.asList(recipe.getInput().getMatchingStacks());
         outputStack = recipe.getOutput().getItemStack();
+        outputFluid = null;
     }
 
     public FluidItemTransformRecipe(FluidItemFluid recipe) {
@@ -44,7 +48,8 @@ public class FluidItemTransformRecipe implements IRecipeWrapper {
         inputBucket = Util.getBucketStack(inputFluid.getFluid());
         inputStacks = Collections.singletonList(recipe.getReactant().getItemStack());
 
-        outputStack = Util.getBucketStack(FluidRegistry.getFluid(recipe.getOutput()));
+        outputFluid = new FluidStack(FluidRegistry.getFluid(recipe.getOutput()), 1000);
+        outputStack = Util.getBucketStack(outputFluid.getFluid());
     }
 
     @Override
@@ -53,6 +58,8 @@ public class FluidItemTransformRecipe implements IRecipeWrapper {
         ingredients.setInputs(VanillaTypes.FLUID, getFluidInputs());
 
         ingredients.setOutput(VanillaTypes.ITEM, outputStack);
+        if(outputFluid != null)
+            ingredients.setOutput(VanillaTypes.FLUID, outputFluid);
     }
 
     public List<List<ItemStack>> getInputs() {

--- a/src/main/java/exnihilocreatio/compatibility/jei/barrel/fluiditemtransform/FluidItemTransformRecipe.java
+++ b/src/main/java/exnihilocreatio/compatibility/jei/barrel/fluiditemtransform/FluidItemTransformRecipe.java
@@ -1,8 +1,9 @@
-package exnihilocreatio.compatibility.jei.barrel.fluidblocktransform;
+package exnihilocreatio.compatibility.jei.barrel.fluiditemtransform;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import exnihilocreatio.registries.types.FluidBlockTransformer;
+import exnihilocreatio.registries.types.FluidItemFluid;
 import exnihilocreatio.util.Util;
 import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.ingredients.VanillaTypes;
@@ -17,7 +18,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-public class FluidBlockTransformRecipe implements IRecipeWrapper {
+public class FluidItemTransformRecipe implements IRecipeWrapper {
 
     @Nonnull
     private final FluidStack inputFluid;
@@ -25,16 +26,25 @@ public class FluidBlockTransformRecipe implements IRecipeWrapper {
     private final ItemStack inputBucket;
     @Nonnull
     private final List<ItemStack> inputStacks;
+
     @Nonnull
     private final ItemStack outputStack;
 
-    public FluidBlockTransformRecipe(FluidBlockTransformer recipe) {
+    public FluidItemTransformRecipe(FluidBlockTransformer recipe) {
         inputFluid = new FluidStack(FluidRegistry.getFluid(recipe.getFluidName()), 1000);
 
         inputBucket = Util.getBucketStack(inputFluid.getFluid());
 
         inputStacks = Arrays.asList(recipe.getInput().getMatchingStacks());
         outputStack = recipe.getOutput().getItemStack();
+    }
+
+    public FluidItemTransformRecipe(FluidItemFluid recipe) {
+        inputFluid = new FluidStack(FluidRegistry.getFluid(recipe.getInputFluid()), 1000);
+        inputBucket = Util.getBucketStack(inputFluid.getFluid());
+        inputStacks = Collections.singletonList(recipe.getReactant().getItemStack());
+
+        outputStack = Util.getBucketStack(FluidRegistry.getFluid(recipe.getOutput()));
     }
 
     @Override

--- a/src/main/java/exnihilocreatio/compatibility/jei/barrel/fluiditemtransform/FluidItemTransformRecipeCategory.java
+++ b/src/main/java/exnihilocreatio/compatibility/jei/barrel/fluiditemtransform/FluidItemTransformRecipeCategory.java
@@ -1,4 +1,4 @@
-package exnihilocreatio.compatibility.jei.barrel.fluidblocktransform;
+package exnihilocreatio.compatibility.jei.barrel.fluiditemtransform;
 
 import exnihilocreatio.ExNihiloCreatio;
 import exnihilocreatio.ModBlocks;
@@ -14,13 +14,13 @@ import net.minecraft.util.ResourceLocation;
 
 import javax.annotation.Nonnull;
 
-public class FluidBlockTransformRecipeCategory implements IRecipeCategory<FluidBlockTransformRecipe> {
+public class FluidItemTransformRecipeCategory implements IRecipeCategory<FluidItemTransformRecipe> {
     public static final String UID = "exnihilocreatio:fluid_block_transform";
     private static final ResourceLocation texture = new ResourceLocation(ExNihiloCreatio.MODID, "textures/gui/jei_fluid_block_transform.png");
 
     private final IDrawableStatic background;
 
-    public FluidBlockTransformRecipeCategory(IGuiHelper helper) {
+    public FluidItemTransformRecipeCategory(IGuiHelper helper) {
         this.background = helper.createDrawable(texture, 0, 0, 166, 63);
     }
 
@@ -33,7 +33,7 @@ public class FluidBlockTransformRecipeCategory implements IRecipeCategory<FluidB
     @Override
     @Nonnull
     public String getTitle() {
-        return "Fluid Block Transform";
+        return "Fluid+Item Transform";
     }
 
     @Override
@@ -54,7 +54,7 @@ public class FluidBlockTransformRecipeCategory implements IRecipeCategory<FluidB
     }
 
     @SuppressWarnings("Duplicates")
-    private void setRecipe(IRecipeLayout recipeLayout, FluidBlockTransformRecipe recipeWrapper) {
+    private void setRecipe(IRecipeLayout recipeLayout, FluidItemTransformRecipe recipeWrapper) {
         recipeLayout.getItemStacks().init(0, true, 74, 36);
         recipeLayout.getItemStacks().init(1, true, 47, 36);
         recipeLayout.getItemStacks().init(2, true, 74, 9);
@@ -67,7 +67,7 @@ public class FluidBlockTransformRecipeCategory implements IRecipeCategory<FluidB
     }
 
     @Override
-    public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull FluidBlockTransformRecipe recipeWrapper, @Nonnull IIngredients ingredients) {
+    public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull FluidItemTransformRecipe recipeWrapper, @Nonnull IIngredients ingredients) {
         // I learn from the best
         setRecipe(recipeLayout, recipeWrapper);
     }

--- a/src/main/java/exnihilocreatio/compatibility/jei/crook/CrookRecipeCategory.java
+++ b/src/main/java/exnihilocreatio/compatibility/jei/crook/CrookRecipeCategory.java
@@ -2,8 +2,8 @@ package exnihilocreatio.compatibility.jei.crook;
 
 import exnihilocreatio.ExNihiloCreatio;
 import exnihilocreatio.registries.manager.ExNihiloRegistryManager;
-import exnihilocreatio.registries.types.CrookReward;
 import exnihilocreatio.util.ItemUtil;
+import exnihilocreatio.util.StringUtils;
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IDrawable;
 import mezz.jei.api.gui.IDrawableStatic;
@@ -111,17 +111,9 @@ public class CrookRecipeCategory implements IRecipeCategory<CrookRecipe> {
                 @SuppressWarnings("deprecation")
                 IBlockState block = blockBase.getStateFromMeta(blockStack.getMetadata());
 
-                List<CrookReward> allRewards = ExNihiloRegistryManager.CROOK_REGISTRY.getRewards(block);
-
-                allRewards.removeIf(reward -> !ItemUtil.areStacksEquivalent(reward.getStack(), ingredient));
-
-                for (CrookReward reward : allRewards) {
-                    float chance = 100.0F * reward.getChance();
-
-                    String format = chance >= 10 ? " - %3.0f%% (x%d)" : "%1.1f%% - (x%d)";
-
-                    tooltip.add(String.format(format, chance, reward.getStack().getCount()));
-                }
+                ExNihiloRegistryManager.CROOK_REGISTRY.getRewards(block).stream()
+                        .filter(reward -> ItemUtil.areStacksEquivalent(reward.getStack(), ingredient))
+                        .forEach(reward -> tooltip.add(String.format("%s (x%d)", StringUtils.formatPercent(reward.getChance()), reward.getStack().getCount())));
             }
         }
     }

--- a/src/main/java/exnihilocreatio/compatibility/jei/hammer/HammerRecipeCategory.java
+++ b/src/main/java/exnihilocreatio/compatibility/jei/hammer/HammerRecipeCategory.java
@@ -6,6 +6,7 @@ import exnihilocreatio.ExNihiloCreatio;
 import exnihilocreatio.registries.manager.ExNihiloRegistryManager;
 import exnihilocreatio.registries.types.HammerReward;
 import exnihilocreatio.util.ItemUtil;
+import exnihilocreatio.util.StringUtils;
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IDrawable;
 import mezz.jei.api.gui.IDrawableStatic;
@@ -141,16 +142,8 @@ public class HammerRecipeCategory implements IRecipeCategory<HammerRecipe> {
 
                 for (int level : levelOrder) {
                     tooltip.add(I18n.format("jei.hammer.hammerLevel." + level));
-
-                    List<HammerReward> rewards = tieredOutputs.get(level);
-
-                    for (HammerReward reward : rewards) {
-                        float chance = 100.0F * reward.getChance();
-
-                        String format = chance >= 10 ? " - %3.0f%% (x%d)" : "%1.1f%% - (x%d)";
-
-                        tooltip.add(String.format(format, chance, reward.getStack().getCount()));
-                    }
+                    tieredOutputs.get(level).forEach(reward ->
+                            tooltip.add(String.format("%s (x%d)", StringUtils.formatPercent(reward.getChance()), reward.getStack().getCount())));
                 }
             }
         }

--- a/src/main/java/exnihilocreatio/compatibility/jei/sieve/SieveRecipeCategory.java
+++ b/src/main/java/exnihilocreatio/compatibility/jei/sieve/SieveRecipeCategory.java
@@ -7,6 +7,7 @@ import exnihilocreatio.registries.manager.ExNihiloRegistryManager;
 import exnihilocreatio.registries.registries.SieveRegistry;
 import exnihilocreatio.registries.types.Siftable;
 import exnihilocreatio.util.ItemUtil;
+import exnihilocreatio.util.StringUtils;
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IDrawable;
 import mezz.jei.api.gui.IDrawableStatic;
@@ -105,14 +106,7 @@ public class SieveRecipeCategory implements IRecipeCategory<SieveRecipe> {
                         if(!ItemUtil.areStacksEquivalent(sifted, ingredient))
                             continue;
 
-                        String s;
-                        int iChance = (int) (siftable.getChance() * 100f);
-                        if (iChance > 0) {
-                            s = String.format("%3d%%", (int) (siftable.getChance() * 100f));
-                        } else {
-                            s = String.format("%1.1f%%", siftable.getChance() * 100f);
-                        }
-                        condensedTooltips.add(s);
+                        condensedTooltips.add(StringUtils.formatPercent(siftable.getChance()));
                     }
                     tooltip.add(I18n.format("jei.sieve.dropChance"));
                     for (String line : condensedTooltips.elementSet()) {

--- a/src/main/java/exnihilocreatio/modules/tconstruct/tools/SledgeHammer.java
+++ b/src/main/java/exnihilocreatio/modules/tconstruct/tools/SledgeHammer.java
@@ -82,14 +82,15 @@ public class SledgeHammer extends AoeToolCore implements IHammer {
     }
 
     @Override
-    public boolean isHammer(ItemStack stack) {
-        return true;
-    }
-
-    @Override
     public int getMiningLevel(ItemStack stack) {
         if(ToolHelper.isBroken(stack))
             return -1;
         return ToolHelper.getHarvestLevelStat(stack);
+    }
+
+    @Override
+    public boolean isHammer(ItemStack stack) {
+        // Don't consider a broken tool a valid hammer.
+        return (stack.getItem() instanceof SledgeHammer) && !ToolHelper.isBroken(stack);
     }
 }

--- a/src/main/java/exnihilocreatio/modules/tconstruct/tools/TiCrook.java
+++ b/src/main/java/exnihilocreatio/modules/tconstruct/tools/TiCrook.java
@@ -79,6 +79,7 @@ public class TiCrook extends AoeToolCore implements ICrook {
 
     @Override
     public boolean isCrook(ItemStack stack) {
-        return true;
+        // Don't consider a broken tool a valid crook.
+        return (stack.getItem() instanceof TiCrook) && !ToolHelper.isBroken(stack);
     }
 }

--- a/src/main/java/exnihilocreatio/registries/registries/FluidBlockTransformerRegistry.java
+++ b/src/main/java/exnihilocreatio/registries/registries/FluidBlockTransformerRegistry.java
@@ -3,7 +3,7 @@ package exnihilocreatio.registries.registries;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 import exnihilocreatio.api.registries.IFluidBlockTransformerRegistry;
-import exnihilocreatio.compatibility.jei.barrel.fluidblocktransform.FluidBlockTransformRecipe;
+import exnihilocreatio.compatibility.jei.barrel.fluiditemtransform.FluidItemTransformRecipe;
 import exnihilocreatio.json.*;
 import exnihilocreatio.registries.ingredient.OreIngredientStoring;
 import exnihilocreatio.registries.manager.ExNihiloRegistryManager;
@@ -146,21 +146,21 @@ public class FluidBlockTransformerRegistry extends BaseRegistryList<FluidBlockTr
     }
 
     @Override
-    public List<FluidBlockTransformRecipe> getRecipeList() {
-        List<FluidBlockTransformRecipe> fluidBlockTransformRecipes = new ArrayList<>();
+    public List<FluidItemTransformRecipe> getRecipeList() {
+        List<FluidItemTransformRecipe> fluidItemTransformRecipes = new ArrayList<>();
 
         for (FluidBlockTransformer transformer : registry) {
             // Make sure everything's registered
             if (FluidRegistry.isFluidRegistered(transformer.getFluidName())
                     && transformer.getInput().getMatchingStacks().length > 0
                     && transformer.getOutput().isValid()) {
-                FluidBlockTransformRecipe recipe = new FluidBlockTransformRecipe(transformer);
+                FluidItemTransformRecipe recipe = new FluidItemTransformRecipe(transformer);
                 if (recipe.isValid()) {
-                    fluidBlockTransformRecipes.add(recipe);
+                    fluidItemTransformRecipes.add(recipe);
                 }
             }
         }
 
-        return fluidBlockTransformRecipes;
+        return fluidItemTransformRecipes;
     }
 }

--- a/src/main/java/exnihilocreatio/registries/registries/FluidItemFluidRegistry.java
+++ b/src/main/java/exnihilocreatio/registries/registries/FluidItemFluidRegistry.java
@@ -1,9 +1,9 @@
 package exnihilocreatio.registries.registries;
 
-import com.google.common.collect.Lists;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 import exnihilocreatio.api.registries.IFluidItemFluidRegistry;
+import exnihilocreatio.compatibility.jei.barrel.fluiditemtransform.FluidItemTransformRecipe;
 import exnihilocreatio.json.CustomBlockInfoJson;
 import exnihilocreatio.json.CustomItemInfoJson;
 import exnihilocreatio.registries.manager.ExNihiloRegistryManager;
@@ -14,10 +14,12 @@ import exnihilocreatio.util.ItemInfo;
 import exnihilocreatio.util.StackInfo;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.FileReader;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class FluidItemFluidRegistry extends BaseRegistryList<FluidItemFluid> implements IFluidItemFluidRegistry {
 
@@ -61,7 +63,10 @@ public class FluidItemFluidRegistry extends BaseRegistryList<FluidItemFluid> imp
     }
 
     @Override
-    public List<?> getRecipeList() {
-        return Lists.newLinkedList();
+    public List<FluidItemTransformRecipe> getRecipeList() {
+        return registry.stream()
+                .filter(it -> FluidRegistry.isFluidRegistered(it.getInputFluid()))
+                .filter(it -> FluidRegistry.isFluidRegistered(it.getOutput()))
+                .map(FluidItemTransformRecipe::new).collect(Collectors.toList());
     }
 }

--- a/src/main/java/exnihilocreatio/util/StringUtils.kt
+++ b/src/main/java/exnihilocreatio/util/StringUtils.kt
@@ -1,0 +1,12 @@
+package exnihilocreatio.util
+
+import java.text.DecimalFormat
+
+object StringUtils {
+    val PERCENT_FORMAT = DecimalFormat("#.##%")
+    /**
+     * Formats a percent, displays no more than 2 decimal digits, doesn't show trailing zeros
+     */
+    @JvmStatic
+    fun formatPercent(num: Double) = PERCENT_FORMAT.format(num)!!
+}


### PR DESCRIPTION
* Broken tinker's tools are no longer considered valid Hammers/Crooks for getting drops.
* Cleaned up some of the JEI tool tip formatting.
* Added FluidItemFluid recipes to the FluidBlockTransform JEI plugin and renamed plugin.

Closes
* Issue #225
* Issue #228
* Issue #230 