### PR TITLE
Update Extreme Reactors compat and liquid heat sources

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-enc_version=0.4.3.2
+enc_version=0.4.4
 
 mc_version=1.12.2
 mc_major=1.12

--- a/src/main/java/exnihilocreatio/recipes/defaults/BigReactors.java
+++ b/src/main/java/exnihilocreatio/recipes/defaults/BigReactors.java
@@ -11,7 +11,6 @@ import exnihilocreatio.texturing.Color;
 import exnihilocreatio.util.BlockInfo;
 import exnihilocreatio.util.ItemInfo;
 import lombok.Getter;
-import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 
 public class BigReactors implements IRecipeDefaults {
@@ -32,24 +31,26 @@ public class BigReactors implements IRecipeDefaults {
     }
 
     public void registerOreChunks(OreRegistry registry) {
-        // 0 = Yellorium
-        Item yellorium = Item.getByNameOrId("bigreactors:ingotmetals");
-        if (yellorium != null) {
-            registry.register("yellorium", new Color("DCF400"), new ItemInfo(yellorium, 0));
+        Item ingot = Item.getByNameOrId("bigreactors:ingotyellorium");
+        Item dust = Item.getByNameOrId("bigreactors:dustyellorium");
+        if (ingot != null) {
+            ItemInfo ingotInfo = new ItemInfo(ingot, -1);
+            ItemInfo dustInfo = new ItemInfo(dust, -1);
+            registry.register("yellorium", new Color("DCF400"), ingotInfo, dustInfo);
             ItemOre ore = ExNihiloRegistryManager.ORE_REGISTRY.getOreItem("yellorium");
             registry.getSieveBlackList().add(ore); //Disables the default sieve recipes
         }
     }
 
     public void registerHeat(HeatRegistry registry) {
-        // 0 = Yellorium
-        // 1 = Cyanite
-        // 3 = Blutonium
-        Block brBlocks = Block.getBlockFromName("bigreactors:blockmetals");
-        if (brBlocks != null) {
-            registry.register(new BlockInfo(brBlocks), 10);
-            registry.register(new BlockInfo(brBlocks, 1), 15);
-            registry.register(new BlockInfo(brBlocks, 3), 20);
+        BlockInfo blockYellorium = new BlockInfo("bigreactors:blockyellorium:-1");
+        BlockInfo blockCyanite = new BlockInfo("bigreactors:blockcyanite:-1");
+        BlockInfo blockBlutonium = new BlockInfo("bigreactors:blockblutonium:-1");
+
+        if (blockYellorium.isValid()) {
+            registry.register(blockYellorium, 10);
+            registry.register(blockCyanite, 15);
+            registry.register(blockBlutonium, 20);
         }
     }
 }

--- a/src/main/java/exnihilocreatio/tiles/TileCrucibleStone.java
+++ b/src/main/java/exnihilocreatio/tiles/TileCrucibleStone.java
@@ -4,6 +4,7 @@ import exnihilocreatio.capabilities.CapabilityHeatManager;
 import exnihilocreatio.registries.manager.ExNihiloRegistryManager;
 import exnihilocreatio.util.BlockInfo;
 import exnihilocreatio.util.ItemInfo;
+import net.minecraft.block.BlockLiquid;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
@@ -13,6 +14,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.IFluidBlock;
 
 public class TileCrucibleStone extends TileCrucibleBase {
 
@@ -79,8 +81,8 @@ public class TileCrucibleStone extends TileCrucibleBase {
     }
 
     public int getHeatRate() {
-        BlockPos posBelow = pos.add(0, -1, 0);
-        IBlockState stateBelow = getWorld().getBlockState(posBelow);
+        final BlockPos posBelow = pos.add(0, -1, 0);
+        final IBlockState stateBelow = getWorld().getBlockState(posBelow);
 
         if (stateBelow == Blocks.AIR.getDefaultState()) {
             return 0;
@@ -93,8 +95,19 @@ public class TileCrucibleStone extends TileCrucibleBase {
         if (heat == 0 && !Item.getItemFromBlock(stateBelow.getBlock()).getHasSubtypes())
             heat = ExNihiloRegistryManager.HEAT_REGISTRY.getHeatAmount(new BlockInfo(stateBelow.getBlock()));
 
-        if (heat != 0)
+        if(heat != 0) {
+            // Check if it is a fluid
+            if(stateBelow.getBlock() instanceof IFluidBlock) {
+                final IFluidBlock fluidBelow = (IFluidBlock) stateBelow.getBlock();
+                final float fillLevel = Math.abs(fluidBelow.getFilledPercentage(getWorld(), posBelow));
+                heat = Math.round(fillLevel * heat);
+            }
+            else if (stateBelow.getBlock() instanceof BlockLiquid) {
+                final float liquidHeight = BlockLiquid.getBlockLiquidHeight(stateBelow, getWorld(), posBelow);
+                heat = Math.round(liquidHeight * heat);
+            }
             return heat;
+        }
 
         TileEntity tile = getWorld().getTileEntity(posBelow);
 


### PR DESCRIPTION
Update Extreme Reactors compat to use item names from the newer extreme reactor versions. JSON files may need to be regenerated.

Liquid heat sources lose effectiveness the further they flow.

Closes
* Issue #231
* Issue #232